### PR TITLE
E2K: added initial support of MCST Elbrus 2000 CPU architecture

### DIFF
--- a/code/curl-7.54.0/include/curl/curlbuild.h
+++ b/code/curl-7.54.0/include/curl/curlbuild.h
@@ -288,19 +288,34 @@
 #  define CURL_SIZEOF_CURL_SOCKLEN_T 4
 
 #elif defined(__LCC__)
-#  define CURL_SIZEOF_LONG           4
-#  define CURL_TYPEOF_CURL_OFF_T     long
-#  define CURL_FORMAT_CURL_OFF_T     "ld"
-#  define CURL_FORMAT_CURL_OFF_TU    "lu"
-#  define CURL_FORMAT_OFF_T          "%ld"
-#  define CURL_SIZEOF_CURL_OFF_T     4
-#  define CURL_SUFFIX_CURL_OFF_T     L
-#  define CURL_SUFFIX_CURL_OFF_TU    UL
-#  define CURL_TYPEOF_CURL_SOCKLEN_T int
-#  define CURL_SIZEOF_CURL_SOCKLEN_T 4
+#  if defined(__e2k__) /* MCST eLbrus C Compiler */
+#    define CURL_SIZEOF_LONG           8
+#    define CURL_TYPEOF_CURL_OFF_T     long
+#    define CURL_FORMAT_CURL_OFF_T     "ld"
+#    define CURL_FORMAT_CURL_OFF_TU    "lu"
+#    define CURL_FORMAT_OFF_T          "%ld"
+#    define CURL_SIZEOF_CURL_OFF_T     8
+#    define CURL_SUFFIX_CURL_OFF_T     L
+#    define CURL_SUFFIX_CURL_OFF_TU    UL
+#    define CURL_TYPEOF_CURL_SOCKLEN_T socklen_t
+#    define CURL_SIZEOF_CURL_SOCKLEN_T 4
+#    define CURL_PULL_SYS_TYPES_H      1
+#    define CURL_PULL_SYS_SOCKET_H     1
+#  else                /* Local (or Little) C Compiler */
+#    define CURL_SIZEOF_LONG           4
+#    define CURL_TYPEOF_CURL_OFF_T     long
+#    define CURL_FORMAT_CURL_OFF_T     "ld"
+#    define CURL_FORMAT_CURL_OFF_TU    "lu"
+#    define CURL_FORMAT_OFF_T          "%ld"
+#    define CURL_SIZEOF_CURL_OFF_T     4
+#    define CURL_SUFFIX_CURL_OFF_T     L
+#    define CURL_SUFFIX_CURL_OFF_TU    UL
+#    define CURL_TYPEOF_CURL_SOCKLEN_T int
+#    define CURL_SIZEOF_CURL_SOCKLEN_T 4
+#  endif
 
 #elif defined(__SYMBIAN32__)
-#  if defined(__EABI__)  /* Treat all ARM compilers equally */
+#  if defined(__EABI__) /* Treat all ARM compilers equally */
 #    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long long
 #    define CURL_FORMAT_CURL_OFF_T     "lld"
@@ -539,7 +554,8 @@
 #    define CURL_SUFFIX_CURL_OFF_T     LL
 #    define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  elif defined(__LP64__) || \
-        defined(__x86_64__) || defined(__ppc64__) || defined(__powerpc64__) || defined(__sparc64__)
+        defined(__x86_64__) || defined(__ppc64__) || defined(__powerpc64__) || defined(__sparc64__) || \
+        defined(__e2k__) /* MCST Elbrus 2000 */
 #    define CURL_SIZEOF_LONG           8
 #    define CURL_TYPEOF_CURL_OFF_T     long
 #    define CURL_FORMAT_CURL_OFF_T     "ld"

--- a/code/qcommon/q_platform.h
+++ b/code/qcommon/q_platform.h
@@ -180,6 +180,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #define PATH_SEP '/'
 
+#if defined (__e2k__)
+#define ARCH_STRING "e2k"
+#undef ide2k
+#define ide2k 1
+#endif // __e2k__
+
 #if !defined(ARCH_STRING)
 # error ARCH_STRING should be defined by the Makefile
 #endif


### PR DESCRIPTION
E2K (Elbrus 2000) - this is VLIW/EPIC architecture, like Intel Itanium (IA-64) architecture.

Ref: https://en.wikipedia.org/wiki/Elbrus_2000